### PR TITLE
Lower the minimum Flask version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ homepage = "https://github.com/fedora-infra/flask-healthz"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-Flask = "^1.1.1"
+Flask = [">=0.12", "<2.0.0"]
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.7"


### PR DESCRIPTION
This module works fine with Flask 0.12 and newer, so lowering the
version required makes it possible to run with Flask shipped in
RHEL/CentOS 8 and other LTS distributions.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>