### PR TITLE
PrefixFilter: handle record.args.status being a str

### DIFF
--- a/flask_healthz/log.py
+++ b/flask_healthz/log.py
@@ -2,6 +2,9 @@ class PrefixFilter:
     def __init__(self, prefix):
         self.prefix = prefix
 
+    # gunicorn seems to be using both int and str for status codes
+    SUCCESS_STATUS = (200, '200')
+
     def filter(self, record):
         url = None
 
@@ -11,6 +14,6 @@ class PrefixFilter:
         do_not_log = (
             url is not None
             and url.startswith(f"{self.prefix}/")
-            and record.args.get("s") == 200
+            and record.args.get("s") in PrefixFilter.SUCCESS_STATUS
         )
         return 0 if do_not_log else 1


### PR DESCRIPTION
record.args.status apparently can be both a str or an int. We now handle both cases.